### PR TITLE
Fix rate limit duration config

### DIFF
--- a/src/pages/api/contact-form-submissions.ts
+++ b/src/pages/api/contact-form-submissions.ts
@@ -42,11 +42,11 @@ export const POST: APIRoute = errorHandlerMiddleware(
 		[
 			clientIpMiddleware,
 			loggerMiddleware,
-			rateLimiterMiddleware({
-				limit: 5,
-				duration: '15 m',
-				prefix: 'emailRateLimiter',
-			}),
+                        rateLimiterMiddleware({
+                                limit: 5,
+                                duration: '15m',
+                                prefix: 'emailRateLimiter',
+                        }),
 			validationMiddleware(contactFormValidationRules),
 		],
 	),


### PR DESCRIPTION
## Summary
- use `15m` duration in contact form rate limiter

## Testing
- `npm test -- -i` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_68449764513c832383396868a0b93567