### PR TITLE
chore(release): publish v0.19.0-beta.1 checkpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,66 @@ Política por capas (qué va aquí vs notas por invitación vs migraciones):
 
 ## [Unreleased]
 
+## [0.19.0-beta.1] - 2026-08-24
+
+Release checkpoint consolidating managed invitation corpus growth, release provenance hardening,
+intake performance, dependency maintenance, and protected fast-forward promotion since
+`v0.18.0-beta.1`.
+
+### Added
+
+- **Managed Invitation Corpus**: Valentina Hernandez joined the managed definition catalog, Renata
+  and Leslie definitions were published, and the local render corpus expanded to 17 invitations.
+- **Promotion Comparison Coverage**: Managed release tooling gained explicit semantic comparison and
+  promotional fingerprint coverage for hosted and uploaded asset representations.
+
+### Changed
+
+- **Managed Release Pipeline**: Release planning now separates provenance state queries, recovers
+  stale provenance safely, and reuses exact Preview approval when the destination is already
+  production-ready.
+- **Intake and Dashboard Loading**: Invitation list queries request only the RSVP content slice,
+  demo synchronization is opt-in, and admin invitation loading is explicit at the consuming view.
+- **Dependency and CI Baseline**: Supported runtime and development dependencies were refreshed;
+  Dependabot updates are grouped by ecosystem area, and repository policy and application checks
+  validate pull requests targeting both integration branches.
+- **Git Promotion Governance**: `develop` receives reviewed changes through pull requests, while
+  `main` accepts only checked fast-forward promotion of the exact validated `develop` commit.
+
+### Fixed
+
+- **Content-Only Asset Parity**: Hosted asset strings and canonical uploaded references now compare
+  by delivery semantics instead of producing false drift during managed promotion.
+- **Editorial Magazine Composition**: Legacy variant normalization, location labels, gallery rail,
+  numbered itinerary, responsive typography, padding, and crop behavior were aligned.
+- **Valentina Social Metadata**: Social sharing metadata reuses the approved portrait asset instead
+  of introducing a conflicting delivery role.
+
+### Removed
+
+- Obsolete preset/demo audit and invitation seed utilities, superseded reports and planning records,
+  and the unused typography compatibility inventory.
+
+### Verification
+
+| Check              | Result                                                                                        |
+| :----------------- | :-------------------------------------------------------------------------------------------- |
+| Repository CI      | Passed — type-check, lint, policy validators, and Astro/Vercel build                          |
+| Tests              | Passed — 502 suites passed, 1 skipped; 5745 tests passed, 1 skipped                           |
+| Browser            | Passed — 42 Playwright tests                                                                  |
+| Database contracts | Passed — RSVP and managed disposable contracts; Local, Preview, and Production audits CURRENT |
+
+### Known issues
+
+- Production dependency audit reports 8 high-severity transitive advisories and no critical
+  advisories. Unsupported overrides remain intentionally excluded while Astro/Vercel upstream
+  resolutions are monitored.
+- Production migration history and structural object audit are CURRENT, while its global schema
+  fingerprint differs from Local/Preview and remains a read-only diagnostic follow-up.
+- One managed invitation remains pending Production promotion. No content or schema mutation is
+  included in this checkpoint; a fresh critical backup and owner authorization remain mandatory
+  before any future Production apply.
+
 ## [0.18.0-beta.1] - 2026-08-18
 
 Release checkpoint consolidating invitation composition, delivery governance, operational status,
@@ -45,19 +105,33 @@ and managed publication changes since `v0.17.0-beta.1`.
 
 ## [0.17.0-beta.1] - 2026-08-11
 
-Feature release consolidating Victoria & Roberto real wedding client invitation provisioning, section-owned structural variants architecture, draft restoration and contract audit tooling, and Git safety v2 lifecycle updates since `v0.16.0-beta.1`.
+Feature release consolidating Victoria & Roberto real wedding client invitation provisioning,
+section-owned structural variants architecture, draft restoration and contract audit tooling, and
+Git safety v2 lifecycle updates since `v0.16.0-beta.1`.
 
 ### Added
 
-- **Victoria & Roberto Wedding Client Invitation**: Managed wedding client invitation (`/boda/victoria-y-roberto`) with custom visual profile, intersection treatments, editorial layout, typography scale, focal points, pending timeline status fallback, and artwork plate map previews on venue cards.
-- **Section-Owned Structural Variants Architecture**: Section-level structural variants (`split-cover`, `split-map`, `split-groups`, `single-keepsake` gallery, `timeline-paper` itinerary) encapsulated into invitation profile styles, with independent gallery variant stylesheet resolution.
-- **Draft Restoration & Contract Audit System**: Services and CLI tools for draft restoration (`invitation:draft-restore`, `invitation:draft-canonicalize`), contract audit (`invitation:draft-audit`), and section restore controls in `InvitationEditor`.
-- **Markdown Table Readability Gate**: Markdown table formatting and validation script (`pnpm validate:markdown-tables` / `pnpm format:markdown-tables`) integrated into `lint-staged` and CI.
+- **Victoria & Roberto Wedding Client Invitation**: Managed wedding client invitation
+  (`/boda/victoria-y-roberto`) with custom visual profile, intersection treatments, editorial
+  layout, typography scale, focal points, pending timeline status fallback, and artwork plate map
+  previews on venue cards.
+- **Section-Owned Structural Variants Architecture**: Section-level structural variants
+  (`split-cover`, `split-map`, `split-groups`, `single-keepsake` gallery, `timeline-paper`
+  itinerary) encapsulated into invitation profile styles, with independent gallery variant
+  stylesheet resolution.
+- **Draft Restoration & Contract Audit System**: Services and CLI tools for draft restoration
+  (`invitation:draft-restore`, `invitation:draft-canonicalize`), contract audit
+  (`invitation:draft-audit`), and section restore controls in `InvitationEditor`.
+- **Markdown Table Readability Gate**: Markdown table formatting and validation script
+  (`pnpm validate:markdown-tables` / `pnpm format:markdown-tables`) integrated into `lint-staged`
+  and CI.
 
 ### Changed
 
-- **SCSS Delivery & Theme Bundles**: Decoupled section variant stylesheets from preset bundles and refactored gallery SCSS using semantic palette tokens.
-- **Git Safety Lifecycle v2**: Hardened pre-commit and lane lifecycle scripts (`pnpm agent:git-safety:start`, `pnpm agent:git-safety:finish`).
+- **SCSS Delivery & Theme Bundles**: Decoupled section variant stylesheets from preset bundles and
+  refactored gallery SCSS using semantic palette tokens.
+- **Git Safety Lifecycle v2**: Hardened pre-commit and lane lifecycle scripts
+  (`pnpm agent:git-safety:start`, `pnpm agent:git-safety:finish`).
 
 ### Verification
 
@@ -69,30 +143,66 @@ Feature release consolidating Victoria & Roberto real wedding client invitation 
 
 ## [0.16.0-beta.1] - 2026-08-07
 
-Comprehensive release consolidating public RSVP SECURITY DEFINER RPC architecture, Daniela y Martín real wedding invitation ship, CLI pipeline consolidations (`pnpm dbs`, `pnpm invitation:release`, `pnpm db:migrate`), multi-lane worktrees, production disaster recovery workflows, admin user authentication management, provisioning reconciliation tools, and agent governance matrices since `v0.15.0-beta.1`.
+Comprehensive release consolidating public RSVP SECURITY DEFINER RPC architecture, Daniela y Martín
+real wedding invitation ship, CLI pipeline consolidations (`pnpm dbs`, `pnpm invitation:release`,
+`pnpm db:migrate`), multi-lane worktrees, production disaster recovery workflows, admin user
+authentication management, provisioning reconciliation tools, and agent governance matrices since
+`v0.15.0-beta.1`.
 
 ### Added
 
-- **Daniela y Martín Wedding Client Invitation**: Managed wedding client invitation (`/boda/daniela-y-martin`) with personalized access section, arch-led family section redesign, custom gifts/gallery composition, and updated footer branding.
+- **Daniela y Martín Wedding Client Invitation**: Managed wedding client invitation
+  (`/boda/daniela-y-martin`) with personalized access section, arch-led family section redesign,
+  custom gifts/gallery composition, and updated footer branding.
 - **CLI Pipeline Consolidations**:
-  - `pnpm dbs`: Unified status command (`scripts/provision/dbs-cli.ts`) for cross-environment inspection (`Local`, `Preview`, `Production`) across `CONTENT` and `SCHEMA`.
-  - `pnpm invitation:release`: Unified invitation release CLI (`scripts/provision/invitation-release-cli.ts`) consolidating publication workflows.
-  - `pnpm db:migrate`: Unified schema migration orchestrator CLI (`scripts/db/migrate-cli.ts`) replacing environment-specific wrappers.
-- **Public Guest RSVP Security RPCs**: Atomic `SECURITY DEFINER` Postgres RPCs (`submit_guest_rsvp`, `verify_guest_access`) eliminating direct public table mutation permissions, backed by schema contract gating, non-locking append-only mutation receipts (`invitation_mutation_receipts`), and isolated disposable contract tests.
-- **Content Parity System**: CLI (`pnpm invitation:content-parity`), contract enforcement, preview-sync RSVP reset awareness, and governance integration across agent rules and domain docs.
-- **Managed Reconciliation & Provisioning CLI**: Guided reconciliation for managed divergence (`c2512140`), identity rekey support for local invitation slug migrations (`3474ea8e`), decoupled `hostLoginAlias` (`59b01a20`), interactive section/field content prompts (`a7fc69c0`), and unified cross-environment inspection CLI (`pnpm dbs`).
-- **Four-Lane Worktree Architecture**: Persistent 4-lane worktree layout (`dev-local`, `dev-preview`, `dev-extra`, `Integration`), worktree status CLI, pre-commit `detached-head` guard, stable per-lane Astro port assignment, Windows-safe PowerShell helper, and runtime environment bootstrap.
-- **Admin Auth & Credentials Management**: Password reset and forced change flow with memorable word-digit passwords (`ChangePasswordModal`), admin rate-limiting (`74ac905d`), managed-user login alias editing (`076a0f5e`), and super-admin global event listing (`/dashboard/admin/invitaciones`).
-- **Production Backup & Recovery Infrastructure**: Encrypted daily Production backup workflow (`62ca2aae`), critical backup manifest generator (`37de18f7`), disposable restore verifier (`db:restore:verify-disposable`), failure stderr reporting (`afb718e8`), and integrity profile cutover support (`9db6b02b`).
-- **Alba Rosa Quiñones Invitation Enhancements**: Age lockup composition on Hero for milestone anniversaries/birthdays (`01467388`), senior-friendly typography/contrast, arch-led family layout, and surname spelling correction (`alba-rosa-quinones`).
-- **Agent Governance Matrix**: Structural routing matrix (`.agent/routing-matrix.yaml`) and code ownership registry (`.agent/ownership.yaml`) with structure validation script (`pnpm validate:structure`).
+  - `pnpm dbs`: Unified status command (`scripts/provision/dbs-cli.ts`) for cross-environment
+    inspection (`Local`, `Preview`, `Production`) across `CONTENT` and `SCHEMA`.
+  - `pnpm invitation:release`: Unified invitation release CLI
+    (`scripts/provision/invitation-release-cli.ts`) consolidating publication workflows.
+  - `pnpm db:migrate`: Unified schema migration orchestrator CLI (`scripts/db/migrate-cli.ts`)
+    replacing environment-specific wrappers.
+- **Public Guest RSVP Security RPCs**: Atomic `SECURITY DEFINER` Postgres RPCs (`submit_guest_rsvp`,
+  `verify_guest_access`) eliminating direct public table mutation permissions, backed by schema
+  contract gating, non-locking append-only mutation receipts (`invitation_mutation_receipts`), and
+  isolated disposable contract tests.
+- **Content Parity System**: CLI (`pnpm invitation:content-parity`), contract enforcement,
+  preview-sync RSVP reset awareness, and governance integration across agent rules and domain docs.
+- **Managed Reconciliation & Provisioning CLI**: Guided reconciliation for managed divergence
+  (`c2512140`), identity rekey support for local invitation slug migrations (`3474ea8e`), decoupled
+  `hostLoginAlias` (`59b01a20`), interactive section/field content prompts (`a7fc69c0`), and unified
+  cross-environment inspection CLI (`pnpm dbs`).
+- **Four-Lane Worktree Architecture**: Persistent 4-lane worktree layout (`dev-local`,
+  `dev-preview`, `dev-extra`, `Integration`), worktree status CLI, pre-commit `detached-head` guard,
+  stable per-lane Astro port assignment, Windows-safe PowerShell helper, and runtime environment
+  bootstrap.
+- **Admin Auth & Credentials Management**: Password reset and forced change flow with memorable
+  word-digit passwords (`ChangePasswordModal`), admin rate-limiting (`74ac905d`), managed-user login
+  alias editing (`076a0f5e`), and super-admin global event listing
+  (`/dashboard/admin/invitaciones`).
+- **Production Backup & Recovery Infrastructure**: Encrypted daily Production backup workflow
+  (`62ca2aae`), critical backup manifest generator (`37de18f7`), disposable restore verifier
+  (`db:restore:verify-disposable`), failure stderr reporting (`afb718e8`), and integrity profile
+  cutover support (`9db6b02b`).
+- **Alba Rosa Quiñones Invitation Enhancements**: Age lockup composition on Hero for milestone
+  anniversaries/birthdays (`01467388`), senior-friendly typography/contrast, arch-led family layout,
+  and surname spelling correction (`alba-rosa-quinones`).
+- **Agent Governance Matrix**: Structural routing matrix (`.agent/routing-matrix.yaml`) and code
+  ownership registry (`.agent/ownership.yaml`) with structure validation script
+  (`pnpm validate:structure`).
 
 ### Changed
 
-- **Editor & Publication Infrastructure**: Provenance tracking for draft mutations (`publication_provenance`), atomic editor metadata/restore RPCs (`3521dfaf`, `9ba24029`), thank-you preview parity via prior published content projection, and field identity preservation in section saves.
-- **Screenshot Engine Architecture**: Modular extraction of capture submodules (`full-page`, `viewport`, `clip`) from monolithic `capture.ts` with document-space full-page capture and granular failure reporting.
-- **Provision & DB Parity**: Decoupled CDN asset probes from promotion plan identity; added portable RSVP `pgcrypto` support and migration deployment compatibility.
-- **Testing & CI Classification**: Deterministic Local Supabase URL stubs for zero-DB CI runs, `@extended` classification for live DB E2E tests, and webServer lifecycle hardening.
+- **Editor & Publication Infrastructure**: Provenance tracking for draft mutations
+  (`publication_provenance`), atomic editor metadata/restore RPCs (`3521dfaf`, `9ba24029`),
+  thank-you preview parity via prior published content projection, and field identity preservation
+  in section saves.
+- **Screenshot Engine Architecture**: Modular extraction of capture submodules (`full-page`,
+  `viewport`, `clip`) from monolithic `capture.ts` with document-space full-page capture and
+  granular failure reporting.
+- **Provision & DB Parity**: Decoupled CDN asset probes from promotion plan identity; added portable
+  RSVP `pgcrypto` support and migration deployment compatibility.
+- **Testing & CI Classification**: Deterministic Local Supabase URL stubs for zero-DB CI runs,
+  `@extended` classification for live DB E2E tests, and webServer lifecycle hardening.
 
 - **Observabilidad direct alignment**: when Local/Preview/Production current managed drafts match
   (including asset slots), delivery can be `ALIGNED` without legacy provenance; otherwise baseline
@@ -102,15 +212,22 @@ Comprehensive release consolidating public RSVP SECURITY DEFINER RPC architectur
 
 ### Fixed
 
-- **Database & Migration Safety**: Enforced `CONFIRM_PROD_MIGRATION` guard in production migration CLI, corrected auth boolean export nullability, and non-locking append-only receipt serialization.
-- **CI & Local Scripts**: Handled non-existent files in changed-files detection script, direct `commitlint` invocation to avoid Windows `cmd.exe` path collisions, and `structuredClone` undefined guard in section merging.
+- **Database & Migration Safety**: Enforced `CONFIRM_PROD_MIGRATION` guard in production migration
+  CLI, corrected auth boolean export nullability, and non-locking append-only receipt serialization.
+- **CI & Local Scripts**: Handled non-existent files in changed-files detection script, direct
+  `commitlint` invocation to avoid Windows `cmd.exe` path collisions, and `structuredClone`
+  undefined guard in section merging.
 
 ### Removed
 
-- **Legacy & Obsolete DB CLI Commands**: `pnpm db:sync`, `pnpm db:local:migrate`, `pnpm db:preview:migrate`, and `pnpm db:prod:migrate` (unified behind `pnpm db:migrate`).
-- **Legacy Invitation Pipeline Commands**: `pnpm invitation:update`, `pnpm invitation:promote`, and `pnpm invitation:approvals:migrate` (unified behind `pnpm invitation:release`).
-- **Approval Scaffolds & Evidence Artifacts**: Retired ad-hoc approval scaffolds and `-evidence` file artifacts from repository and governance docs.
-- **Maintenance Cleanup**: Removed orphaned scripts, legacy segment worktree lanes, outdated asset dumps, and unneeded debug logs.
+- **Legacy & Obsolete DB CLI Commands**: `pnpm db:sync`, `pnpm db:local:migrate`,
+  `pnpm db:preview:migrate`, and `pnpm db:prod:migrate` (unified behind `pnpm db:migrate`).
+- **Legacy Invitation Pipeline Commands**: `pnpm invitation:update`, `pnpm invitation:promote`, and
+  `pnpm invitation:approvals:migrate` (unified behind `pnpm invitation:release`).
+- **Approval Scaffolds & Evidence Artifacts**: Retired ad-hoc approval scaffolds and `-evidence`
+  file artifacts from repository and governance docs.
+- **Maintenance Cleanup**: Removed orphaned scripts, legacy segment worktree lanes, outdated asset
+  dumps, and unneeded debug logs.
 
 ## [0.15.0-beta.1] - 2026-07-28
 
@@ -141,9 +258,9 @@ Alba Rosa Quiñones client invitation, premium motion system, and preview infras
 
 ### Changed
 
-- **Alba Rosa Quiñones**: final editorial redesign — neutral palette, simplified Hero
-  (person → occasion → date), diagonal cuts, café removal, responsive fixes, integrated navy RSVP
-  surface, arch-led Family layout.
+- **Alba Rosa Quiñones**: final editorial redesign — neutral palette, simplified Hero (person →
+  occasion → date), diagonal cuts, café removal, responsive fixes, integrated navy RSVP surface,
+  arch-led Family layout.
 - **Celestial Blue demo**: SVG displacement filter replaced with grain noise on family panel;
   gallery reduced from 10 to 8 images.
 - **Envelope reveal**: integrated multi-renderer seals with wax-monogram anchor on flap fold;
@@ -165,8 +282,8 @@ Alba Rosa Quiñones client invitation, premium motion system, and preview infras
 
 ### Data / model
 
-- New migration: `20260727180000_managed_provenance_projection_baseline` (managed release
-  provenance projection, optimistic concurrency on drafts).
+- New migration: `20260727180000_managed_provenance_projection_baseline` (managed release provenance
+  projection, optimistic concurrency on drafts).
 - Shared content schema: intersection profiles field added.
 
 ## [0.14.0-beta.1]

--- a/docs/core/git-governance.md
+++ b/docs/core/git-governance.md
@@ -1,10 +1,11 @@
 # Git Governance: Commit Policy
 
-**Status:** Active  
-**Last Updated:** 2026-07-26  
-**Change Note:** Documents production-tip recovery when `main` drifts, points agents at
-`branch-lane`, and notes `ALLOW_MAIN_PUSH` for local main pushes. Branch model remains develop trunk
-/ main protected via fast-forward.
+**Status:** Active
+
+**Last Updated:** 2026-08-24
+
+**Change Note:** Aligns the protected-branch rulesets and CI triggers with PR-only integration on
+`develop` and checked fast-forward promotion to `main`.
 
 ## Overview
 
@@ -15,11 +16,12 @@ rules are owned by [`.agent/rules/workflow.md`](../../.agent/rules/workflow.md).
 The repository uses a **linear two-branch workflow** with annotated tags for releases and a
 **four-lane worktree model**:
 
-- `develop` is the active trunk for daily development. Direct commits are allowed.
+- `develop` is the active protected trunk for daily development. Changes land through pull requests
+  after the required checks pass.
 - `main` is the protected production branch, updated only via fast-forward from `develop`.
-- Persistent native Git worktrees (repository root `celebra-me` plus sibling
-  `<repo-dir>-worktrees/` development lanes `dev-local`, `dev-preview`, `dev-extra`) isolate
-  Integration and three development lanes.
+- Persistent native Git worktrees (repository root `celebra-me` plus sibling `<repo-dir>-worktrees/`
+  development lanes `dev-local`, `dev-preview`, `dev-extra`) isolate Integration and three
+  development lanes.
 - Ephemeral task branches (`feat/*`, `fix/*`, `candidate/*`) are checked out in development lanes.
   Permanent lane branches are forbidden.
 - Worktree location grants no environment privilege (`path ≠ privilege`).
@@ -42,18 +44,18 @@ Celebra-me uses native Git worktrees to establish four persistent, reusable oper
 
 1. **Integration** (repository root): Canonical worktree on `develop`. Integration, release
    preparation, trunk operations. Runtime default: Local.
-2. **dev-local** (`<worktrees-root>\dev-local`): Primary feature/fix development on
-   ephemeral task branches. Runtime default: Local.
-3. **dev-preview** (`<worktrees-root>\dev-preview`): Preview development and
-   hosted-validation affinity lane on ephemeral task branches. Runtime default: Preview Supabase via
+2. **dev-local** (`<worktrees-root>\dev-local`): Primary feature/fix development on ephemeral task
+   branches. Runtime default: Local.
+3. **dev-preview** (`<worktrees-root>\dev-preview`): Preview development and hosted-validation
+   affinity lane on ephemeral task branches. Runtime default: Preview Supabase via
    `.env.preview.local`. Preferred lane for authorized Preview operations; path still grants no
    mutation privilege.
-4. **dev-extra** (`<worktrees-root>\dev-extra`): Additional parallel Local development
-   lane on ephemeral task branches. Runtime default: Local.
+4. **dev-extra** (`<worktrees-root>\dev-extra`): Additional parallel Local development lane on
+   ephemeral task branches. Runtime default: Local.
 
 `<worktrees-root>` is the sibling `<repo-dir>-worktrees/` directory next to the repository root —
-the tooling derives it from the checkout root and does not require any particular parent
-directory (see `scripts/shared/worktree-lane.ts`).
+the tooling derives it from the checkout root and does not require any particular parent directory
+(see `scripts/shared/worktree-lane.ts`).
 
 Lane-specific operational cards (facts only; policy stays centralized):
 [`docs/core/worktrees/`](worktrees/).
@@ -331,13 +333,14 @@ judgment.
 ## Active Hooks and CI Sequence
 
 1. `pre-commit` blocks direct commits to `main` unless explicitly bypassed and runs
-   `pnpm lint-staged` on all branches. Commits to `develop` and other branches are allowed.
+   `pnpm lint-staged` on all branches. GitHub rules require pull requests for changes targeting
+   `develop`.
 2. `commit-msg` runs `commitlint` against the pending commit message on all branches.
 3. `pre-push` blocks direct pushes to `main` (override: `ALLOW_MAIN_PUSH=true`) and validates the
    pushed commit range with `scripts/validate-commits.mjs` in audit-only mode.
 4. CI workflow `Repository CI` (`.github/workflows/commit-validation.yml`) runs on push to `develop`
-   and on pull requests targeting `main`. It reports two parallel jobs with non-overlapping
-   validation:
+   and on pull requests targeting `develop` or `main`. It reports two parallel jobs with
+   non-overlapping validation:
    - **Repository Policy** — commit-message range checks and `pnpm ops check-links`
    - **Application Suite** — canonical `pnpm run ci` (after Playwright Chromium install)
      Checkout/pnpm/Node/install setup is duplicated per job because GitHub Actions jobs do not share
@@ -351,9 +354,15 @@ judgment.
 - Commit hygiene warnings stay non-blocking so developers still get feedback without hidden
   automation side effects.
 - Direct commits and pushes to `main` are blocked by local hooks (`pre-commit` / `pre-push`).
-  `develop` is the active trunk — direct commits are allowed but commitlint and lint-staged still
-  apply. Do not assume GitHub classic branch protection or repository rulesets are configured;
-  verify live repository settings when required-check enforcement is needed.
+  `develop` is the active trunk and accepts changes through pull requests. Repository rulesets
+  protect both integration branches:
+  - `develop` requires a pull request, resolved review threads, `Repository Policy`, and
+    `Application Suite`.
+  - `main` blocks deletion and non-fast-forward updates and requires the same checks, but does not
+    require a pull request. This permits an already-validated `develop` commit to be promoted
+    without manufacturing a merge, squash, or rebase commit.
+- Verify the live rulesets before each production promotion; documentation is not proof that remote
+  enforcement is active.
 - Atomicity is expected by policy, but enforced through warnings and review rather than a rigid
   local gate.
 
@@ -376,20 +385,23 @@ Land the fix on `develop`, validate, then fast-forward `main`. That keeps the in
 When a release is ready:
 
 ```bash
-# 1. Ensure develop is up to date and validated
+# 1. Ensure the final develop SHA is up to date and validated
 git checkout develop
 git pull --ff-only
 pnpm run ci
 
-# 2. Fast-forward main to match develop
+# 2. Confirm origin/main is an ancestor, then fast-forward main to match develop
+git fetch origin
+git merge-base --is-ancestor origin/main origin/develop
 git checkout main
+git pull --ff-only origin main
 git merge --ff-only develop
 
-# 3. Tag the release
-git tag -a vX.Y.Z -m "Release vX.Y.Z — summary"
-
-# 4. Push main and the tag (local pre-push blocks main without the override)
+# 3. Push main after the exact develop SHA has both required checks
 ALLOW_MAIN_PUSH=true git push origin main
+
+# 4. Verify the deployment, then tag the exact promoted SHA
+git tag -a vX.Y.Z -m "Release vX.Y.Z — summary"
 git push origin vX.Y.Z
 ```
 
@@ -399,6 +411,8 @@ Rules:
 - `git merge --ff-only` fails if `main` has drifted; do not force-push to “fix” it.
 - Tags are annotated (`-a`) to carry release metadata.
 - Never rewrite or force-push `main` without explicit approval.
+- The `main` ruleset deliberately omits the pull-request rule. Required checks are reused from the
+  exact commit already validated on `develop`; no bypass actor is configured.
 - Rollback: `git revert` on `develop`, then fast-forward promote again.
 - Direct commits on `main` are blocked by `pre-commit`; promotion is FF-only from `develop`.
 

--- a/docs/core/release-process.md
+++ b/docs/core/release-process.md
@@ -1,7 +1,8 @@
 # Release Process — Celebra-me
 
-**Status:** Active  
-**Last Updated:** 2026-07-26
+**Status:** Active
+
+**Last Updated:** 2026-08-24
 
 ## Overview
 
@@ -116,39 +117,46 @@ as Added / Changed / Fixed). Optionally append verification notes for the checkp
 
 Reset `[Unreleased]` to an empty pending section after the promotion.
 
-### 4. Commit the changes
+### 4. Commit the changes through `develop`
 
 ```bash
-git add package.json CHANGELOG.md docs/core/release-process.md README.md
-git commit -m "docs(release): add release checkpoint process and v0.X.Y baseline"
+git switch -c candidate/vX.Y.Z develop
+git add package.json CHANGELOG.md
+git commit -m "chore(release): publish vX.Y.Z checkpoint"
 ```
 
-### 5. Create an annotated Git tag
+Open a pull request to `develop`, wait for `Repository Policy` and `Application Suite`, and merge
+without squashing when preceding atomic commits must remain distinct. Revalidate the final `develop`
+SHA after the merge.
+
+### 5. Promote the validated commit to `main`
+
+```bash
+git switch main
+git pull --ff-only origin main
+git merge --ff-only develop
+ALLOW_MAIN_PUSH=true git push origin main
+```
+
+The `main` ruleset requires the same checks as `develop` but intentionally omits the pull-request
+rule. The promotion must reuse the exact checked `develop` SHA and must not create a merge, squash,
+or rebase commit.
+
+### 6. Verify the promoted deployment
+
+Confirm that `origin/main` and `origin/develop` resolve to the same SHA, then verify the automatic
+production deployment and critical smoke routes. If the deployment fails, revert on `develop`,
+validate, and promote the revert by fast-forward; never rewrite `main`.
+
+### 7. Create and push the annotated tag
 
 ```bash
 git tag -a v0.X.Y -m "v0.X.Y - Short description of checkpoint"
-```
-
-### 6. Verify before pushing
-
-Re-run the full verification suite:
-
-```bash
-pnpm lint
-pnpm type-check
-pnpm test --runInBand
-pnpm build
-```
-
-If any check fails, fix the issue or explicitly document the failure before tagging. Do not push a
-tag over a failing verification without a clear record.
-
-### 7. Push
-
-```bash
-git push
 git push origin v0.X.Y
 ```
+
+The tag is created only after the exact promoted deployment is verified. Do not force-update an
+existing tag.
 
 ## Database-dependent releases
 

--- a/docs/core/release-process.md
+++ b/docs/core/release-process.md
@@ -33,6 +33,8 @@ Keep one history owner per change type. Do not dump every commit, migration, or 
 - Do **not** require a changelog entry for every commit.
 - Prefer updating `[Unreleased]` in the same milestone PR/work unit that ships the behavior, not
   only at tag time.
+- If continuous notes were missed and `[Unreleased]` is empty at release preparation, stop and
+  reconstruct it from the audited latest-tag-to-HEAD range before cutting the version section.
 - Per-client operational detail stays in `docs/invitations/<slug>.md`; link or summarize in
   `[Unreleased]` only for notable ships.
 
@@ -40,7 +42,8 @@ Keep one history owner per change type. Do not dump every commit, migration, or 
 
 Before creating a version tag, complete this **pre-tag checklist** (all must pass):
 
-- [ ] `[Unreleased]` contains at least one real bullet (not only HTML comments / empty headings).
+- [ ] The versioned section contains at least one real bullet sourced from accumulated
+      `[Unreleased]` notes or an explicitly audited latest-tag-to-HEAD reconstruction.
 - [ ] No wholesale paste of `docs/invitations/<slug>.md` ops notes into the changelog.
 - [ ] Schema impact is summarized only; full history remains in `supabase/migrations/`.
 - [ ] Promote `[Unreleased]` bullets into `## [X.Y.Z] - YYYY-MM-DD` (Keep a Changelog groups).
@@ -92,7 +95,9 @@ Set the `version` field to the chosen version **without** the leading `v`:
 ### 3. Update `CHANGELOG.md`
 
 Promote accumulated `[Unreleased]` items into a dated version section (Keep a Changelog groups such
-as Added / Changed / Fixed). Optionally append verification notes for the checkpoint:
+as Added / Changed / Fixed). When continuous notes are missing, first reconstruct and review those
+items from the latest valid tag through the candidate HEAD. Optionally append verification notes for
+the checkpoint:
 
 ```markdown
 ## [0.2.0-beta.1] - 2026-05-23
@@ -132,6 +137,8 @@ SHA after the merge.
 ### 5. Promote the validated commit to `main`
 
 ```bash
+git switch develop
+git pull --ff-only origin develop
 git switch main
 git pull --ff-only origin main
 git merge --ff-only develop

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "celebra-me.com",
     "type": "module",
-    "version": "0.18.0-beta.1",
+    "version": "0.19.0-beta.1",
     "engines": {
         "node": ">=22.13.0 <25"
     },


### PR DESCRIPTION
## Summary

- document PR-only integration on `develop` and checked fast-forward promotion to `main`
- publish the `v0.19.0-beta.1` changelog checkpoint and align `package.json`
- preserve Framer Motion and the current Vercel toolchain; major upgrades remain separate

## Validation

- `pnpm run ci` — passed: 1,596 files with 0 diagnostics; 502 suites passed, 1 skipped; 5,745 tests passed, 1 skipped; 42 Playwright tests passed; Astro/Vercel build passed
- `pnpm test:db:rsvp-contracts` — passed against disposable-test with 76 migrations
- `pnpm test:db:managed-contracts` — passed against disposable-test with 76 migrations
- `pnpm exec tsx scripts/db/sentinel-check.ts check` — persistent Local sentinel preserved
- `pnpm db:branch:parity -- --base origin/main --head HEAD --json` — passed; no sensitive changes or migration drift
- `pnpm db:local:audit`, `pnpm db:preview:audit`, `pnpm db:prod:audit` — passed; all targets CURRENT at 76/76 with zero structural findings
- `pnpm audit --prod` — 0 critical, 8 high transitive advisories (accepted documented upstream risk)

## Risk / operational impact

- no application source, migration, managed content, or database write is included
- Production's global schema fingerprint differs from Local/Preview although the structural audit passes; follow-up remains read-only
- the existing combined ruleset still requires a PR on `main`; it will be split only after this PR lands and the final `develop` SHA is green
- Prettier normalized historical wrapping in `CHANGELOG.md` because Markdown formatting is mandatory in the pre-commit hook